### PR TITLE
Fix UUID mismatch on config import after new install.

### DIFF
--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -44,9 +44,9 @@ module:
   user: 0
   views_ui: 0
   views: 10
-  standard: 1000
+  minimal: 1000
 theme:
   claro: 0
   gin: 0
   olivero: 0
-profile: standard
+profile: minimal

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -1,5 +1,5 @@
 # Install empty Drupal site with user 1 as admin/admin
-ddev drush si -y --account-pass=admin --site-name='Labdoo3.0' standard
+ddev drush si -y --account-pass=admin --site-name='Labdoo3.0' minimal
 # Force the new site UUID to be the same as the configuration
 ddev drush config:set 'system.site' uuid 'e5f3dd3c-79fa-4957-84db-90fc98effac5' -y
 # Install any Drupal database updates

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -1,5 +1,7 @@
 # Install empty Drupal site with user 1 as admin/admin
 ddev drush si -y --account-pass=admin --site-name='Labdoo3.0' standard
+# Force the new site UUID to be the same as the configuration
+ddev drush config:set 'system.site' uuid 'e5f3dd3c-79fa-4957-84db-90fc98effac5' -y
 # Install any Drupal database updates
 ddev drush updb -y
 # Do a drush configuration import twice in case first import enables additional configuration (e.g. config_ignore or config_split)


### PR DESCRIPTION
This resolves the inability to import configuration during a Gitpod workspace setup.  Also switched the initial install profile to minimal to avoid issues from Drupal options installed by the standard profile conflicting with configuration imports.