### PR TITLE
Update gitpod.yml to use latest version of DDEV

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,4 @@
-image:
-  file: .gitpod.Dockerfile
+image: drupalpod/drupalpod-gitpod-base:latest
 
 # ddev and composer are running as part of the prebuild
 # when starting a workspace all docker images are ready


### PR DESCRIPTION
Shaal released an update to drupalpo,d that I based our configuration on, that uses a custom docker image that tracks the latest version of DDEV so we will always be up to date in Gitpod.  Local DDEV installs will need to keep updating then prompted.