### PR TITLE
Remove test module added by mistake

### DIFF
--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -18,7 +18,6 @@ module:
   datetime: 0
   dblog: 0
   default_content: 0
-  default_content_test: 0
   dynamic_page_cache: 0
   editor: 0
   field: 0


### PR DESCRIPTION
@greggmarshall in my last merge (https://github.com/Labdoo/Labdoo-3.0/pull/25) I broke main branch by accidentally attempting to install a module that does not exist. This should fixed it I think. I tested it by rebuilding Labdoo 3.0:

```
ddev composer install

ddev drush updb

ddev drush cim

ddev drush cim

ddev drush cr
```